### PR TITLE
fix: generate parser for ABI in stable Neovim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 all:
-	tree-sitter generate --abi=latest
+	tree-sitter generate --abi=13
 	tree-sitter test
 
 run: all

--- a/src/parser.c
+++ b/src/parser.c
@@ -13,7 +13,7 @@
 #pragma GCC optimize ("O0")
 #endif
 
-#define LANGUAGE_VERSION 14
+#define LANGUAGE_VERSION 13
 #define STATE_COUNT 1458
 #define LARGE_STATE_COUNT 141
 #define SYMBOL_COUNT 462
@@ -67673,7 +67673,6 @@ extern const TSLanguage *tree_sitter_vim(void) {
       tree_sitter_vim_external_scanner_serialize,
       tree_sitter_vim_external_scanner_deserialize,
     },
-    .primary_state_ids = ts_primary_state_ids,
   };
   return &language;
 }


### PR DESCRIPTION
While specifying `--abi` is required in tree-sitter CLI 0.20.3, fixing this at `latest` makes the parser incompatible with Neovim stable (which, among other things, breaks nvim-treesitter CI). Fix ABI at 13 instead (to be bumped to 14 with the next Neovim release).