### PR TITLE
Fix keyword recognition when mandatory part is incomplete

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -362,6 +362,10 @@ bool try_lex_keyword(char *possible, keyword keyword) {
     }
   }
 
+  // The mandatory part is not complete
+  if (keyword.mandat[i] && !possible[i])
+    return false;
+
   size_t mandat_len = i;
   // Now try lexing optional part
   for (size_t i = 0; keyword.opt[i] && possible[mandat_len + i]; i++) {


### PR DESCRIPTION
For the moment,
```vim
s !make
```
is recognized as a `silent_statement`, `sil` is the mandatory part
and
```vim
w =
```
as a `wincmd_statement`, `winc` is the mandatory part

Signed-off-by: Fymyte <pierguill@gmail.com>
