### PR TITLE
Add `source` keyword

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -67,6 +67,7 @@
   "augroup"
   "return"
   "syntax"
+  "source"
   "lua"
   "ruby"
   "perl"

--- a/test/highlight/source.vim
+++ b/test/highlight/source.vim
@@ -1,0 +1,10 @@
+" Last Change: 2022 Sep 27
+
+source path/to/file
+" <- keyword
+"      ^ string
+
+source! path/to/file
+" <- keyword
+"     ^ punctuation.special
+"       ^ string


### PR DESCRIPTION
The `source` keyword doesn't get highlighted. Following the contribution guidelines I checked `grammar.js` and `keywords.js` and it's present in both, this is the only file where it's not listed, so I'm assuming that's the issue.