### PR TITLE
Filetype keyword

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -283,7 +283,7 @@ module.exports = grammar({
     _filetype_enable: ($) => sub_cmd($._filetype_state),
     _filetype_detect: ($) => sub_cmd("detect"),
     _filetype_plugin: ($) => sub_cmd("plugin", optional("indent"), $._filetype_state),
-    _filetype_indent: ($) => sub_cmd("indent", optional("plugin"), $._filetype_state)
+    _filetype_indent: ($) => sub_cmd("indent", optional("plugin"), $._filetype_state),
     filetype_statement: ($) =>
       command(
         $,

--- a/grammar.js
+++ b/grammar.js
@@ -282,8 +282,10 @@ module.exports = grammar({
     _filetype_state: ($) => choice("on", "off"),
     _filetype_enable: ($) => sub_cmd($._filetype_state),
     _filetype_detect: ($) => sub_cmd("detect"),
-    _filetype_plugin: ($) => sub_cmd("plugin", optional("indent"), $._filetype_state),
-    _filetype_indent: ($) => sub_cmd("indent", optional("plugin"), $._filetype_state),
+    _filetype_plugin: ($) =>
+      sub_cmd("plugin", optional("indent"), $._filetype_state),
+    _filetype_indent: ($) =>
+      sub_cmd("indent", optional("plugin"), $._filetype_state),
     filetype_statement: ($) =>
       command(
         $,

--- a/grammar.js
+++ b/grammar.js
@@ -280,17 +280,20 @@ module.exports = grammar({
       ),
 
     _filetype_state: ($) => choice("on", "off"),
+    _filetype_enable: ($) => sub_cmd($._filetype_state),
+    _filetype_detect: ($) => sub_cmd("detect"),
+    _filetype_plugin: ($) => sub_cmd("plugin", $._filetype_state),
+    _filetype_indent: ($) => sub_cmd("indent", $._filetype_state),
     filetype_statement: ($) =>
-      seq(
-        keyword($, "filetype"),
+      command(
+        $,
+        "filetype",
         optional(
           choice(
-            seq(
-              optional("plugin"),
-              optional("indent"),
-              alias($._filetype_state, $.state)
-            ),
-            "detect"
+            $._filetype_enable,
+            $._filetype_detect,
+            $._filetype_plugin,
+            $._filetype_indent
           )
         )
       ),

--- a/grammar.js
+++ b/grammar.js
@@ -282,8 +282,8 @@ module.exports = grammar({
     _filetype_state: ($) => choice("on", "off"),
     _filetype_enable: ($) => sub_cmd($._filetype_state),
     _filetype_detect: ($) => sub_cmd("detect"),
-    _filetype_plugin: ($) => sub_cmd("plugin", $._filetype_state),
-    _filetype_indent: ($) => sub_cmd("indent", $._filetype_state),
+    _filetype_plugin: ($) => sub_cmd("plugin", optional("indent"), $._filetype_state),
+    _filetype_indent: ($) => sub_cmd("indent", optional("plugin"), $._filetype_state)
     filetype_statement: ($) =>
       command(
         $,

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -104,6 +104,16 @@
 (map_statement cmd: _ @keyword)
 (command_name) @function.macro
 
+;; Filetype command
+
+(filetype_statement (keyword) @string)
+(filetype_statement [
+  "plugin"
+  "indent"
+  "on"
+  "off"
+] @keyword)
+
 ;; Syntax command
 
 (syntax_statement (keyword) @string)

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -67,6 +67,7 @@
   "augroup"
   "return"
   "syntax"
+  "filetype"
   "source"
   "lua"
   "ruby"

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -107,6 +107,7 @@
 ;; Filetype command
 
 (filetype_statement [
+  "detect"
   "plugin"
   "indent"
   "on"

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -106,7 +106,6 @@
 
 ;; Filetype command
 
-(filetype_statement (keyword) @string)
 (filetype_statement [
   "plugin"
   "indent"

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1721,6 +1721,80 @@
         }
       ]
     },
+    "_filetype_enable": {
+      "type": "FIELD",
+      "name": "sub",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_filetype_state"
+      }
+    },
+    "_filetype_detect": {
+      "type": "FIELD",
+      "name": "sub",
+      "content": {
+        "type": "STRING",
+        "value": "detect"
+      }
+    },
+    "_filetype_plugin": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "sub",
+          "content": {
+            "type": "STRING",
+            "value": "plugin"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "indent"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_filetype_state"
+        }
+      ]
+    },
+    "_filetype_indent": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "sub",
+          "content": {
+            "type": "STRING",
+            "value": "indent"
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "plugin"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_filetype_state"
+        }
+      ]
+    },
     "filetype_statement": {
       "type": "SEQ",
       "members": [
@@ -1740,46 +1814,20 @@
               "type": "CHOICE",
               "members": [
                 {
-                  "type": "SEQ",
-                  "members": [
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "plugin"
-                        },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "indent"
-                        },
-                        {
-                          "type": "BLANK"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "ALIAS",
-                      "content": {
-                        "type": "SYMBOL",
-                        "name": "_filetype_state"
-                      },
-                      "named": true,
-                      "value": "state"
-                    }
-                  ]
+                  "type": "SYMBOL",
+                  "name": "_filetype_enable"
                 },
                 {
-                  "type": "STRING",
-                  "value": "detect"
+                  "type": "SYMBOL",
+                  "name": "_filetype_detect"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_filetype_plugin"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_filetype_indent"
                 }
               ]
             },
@@ -7903,7 +7951,7 @@
             },
             {
               "type": "PATTERN",
-              "value": "[\\/._+,#$%~=-]"
+              "value": "[/._+,#$%~=-]"
             },
             {
               "type": "PATTERN",
@@ -7944,7 +7992,7 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[\\/._+,#$%~=-]"
+                  "value": "[/._+,#$%~=-]"
                 }
               },
               {
@@ -8227,7 +8275,7 @@
     },
     "register": {
       "type": "PATTERN",
-      "value": "@[\"0-9a-zA-Z:.%#=*+_\\/-@]"
+      "value": "@[\"0-9a-zA-Z:.%#=*+_/-@]"
     },
     "option": {
       "type": "SEQ",

--- a/src/keywords.h
+++ b/src/keywords.h
@@ -43,8 +43,8 @@ typedef enum {
   CMAP = 41,
   TMAP = 42,
   NOREMAP = 43,
-  VNOREMAP = 44,
-  NNOREMAP = 45,
+  NNOREMAP = 44,
+  VNOREMAP = 45,
   XNOREMAP = 46,
   SNOREMAP = 47,
   ONOREMAP = 48,
@@ -316,12 +316,12 @@ keyword keywords[] = {
     .opt = "remap",
     .ignore_comments_after = true
   },
-  [VNOREMAP] = {
+  [NNOREMAP] = {
     .mandat = "nn",
     .opt = "oremap",
     .ignore_comments_after = true
   },
-  [NNOREMAP] = {
+  [VNOREMAP] = {
     .mandat = "vn",
     .opt = "oremap",
     .ignore_comments_after = true

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3796,16 +3796,33 @@
   {
     "type": "filetype_statement",
     "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "state",
-          "named": true
-        }
-      ]
+    "fields": {
+      "sub": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "detect",
+            "named": false
+          },
+          {
+            "type": "indent",
+            "named": false
+          },
+          {
+            "type": "off",
+            "named": false
+          },
+          {
+            "type": "on",
+            "named": false
+          },
+          {
+            "type": "plugin",
+            "named": false
+          }
+        ]
+      }
     }
   },
   {
@@ -7855,11 +7872,6 @@
     }
   },
   {
-    "type": "state",
-    "named": true,
-    "fields": {}
-  },
-  {
     "type": "stopinsert_statement",
     "named": true,
     "fields": {}
@@ -10431,11 +10443,11 @@
   },
   {
     "type": "file",
-    "named": true
+    "named": false
   },
   {
     "type": "file",
-    "named": false
+    "named": true
   },
   {
     "type": "file_format",

--- a/test/corpus/filetype_statement.txt
+++ b/test/corpus/filetype_statement.txt
@@ -1,5 +1,5 @@
 ================================================================================
-Filtypes
+Filetype
 ================================================================================
 
 filetype on
@@ -14,19 +14,11 @@ filetype plugin indent off
 --------------------------------------------------------------------------------
 
 (script_file
-  (filetype_statement
-    (state))
-  (filetype_statement
-    (state))
-  (filetype_statement
-    (state))
-  (filetype_statement
-    (state))
-  (filetype_statement
-    (state))
-  (filetype_statement
-    (state))
-  (filetype_statement
-    (state))
-  (filetype_statement
-    (state)))
+  (filetype_statement)
+  (filetype_statement)
+  (filetype_statement)
+  (filetype_statement)
+  (filetype_statement)
+  (filetype_statement)
+  (filetype_statement)
+  (filetype_statement))

--- a/test/highlight/filetype_statement.vim
+++ b/test/highlight/filetype_statement.vim
@@ -3,14 +3,11 @@ filetype
 
 filetype on
 " <- keyword
-"        ^ state
 
 filet plugin off
 " <- keyword
 "     ^ keyword
-"            ^ state
 
 filet indent off
 " <- keyword
 "     ^ keyword
-"            ^ state

--- a/test/highlight/filetype_statement.vim
+++ b/test/highlight/filetype_statement.vim
@@ -3,6 +3,11 @@ filetype
 
 filetype on
 " <- keyword
+"        ^ keyword
+
+filet detect
+" <- keyword
+"     ^ keyword
 
 filet plugin off
 " <- keyword

--- a/test/highlight/filetype_statement.vim
+++ b/test/highlight/filetype_statement.vim
@@ -1,0 +1,16 @@
+filetype
+" <- keyword
+
+filetype on
+" <- keyword
+"        ^ state
+
+filet plugin off
+" <- keyword
+"     ^ keyword
+"            ^ state
+
+filet indent off
+" <- keyword
+"     ^ keyword
+"            ^ state


### PR DESCRIPTION
I noticed that also the `filetype` keyword doesn't get highlighted properly, so I added it to `queries/highlights.scm` and added a test file.