### PR TITLE
fix: incorrect parsing when `a:var` follows `elseif`

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -357,6 +357,7 @@ module.exports = grammar({
       seq(
         keyword($, "elseif"),
         field("condition", $._expression),
+        $._cmd_separator,
         alias(optional($._separated_statements), $.body)
       ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2254,6 +2254,10 @@
           }
         },
         {
+          "type": "SYMBOL",
+          "name": "_cmd_separator"
+        },
+        {
           "type": "ALIAS",
           "content": {
             "type": "CHOICE",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -3521,11 +3521,15 @@
       }
     },
     "children": {
-      "multiple": false,
+      "multiple": true,
       "required": false,
       "types": [
         {
           "type": "body",
+          "named": true
+        },
+        {
+          "type": "comment",
           "named": true
         }
       ]

--- a/test/corpus/if_statement.txt
+++ b/test/corpus/if_statement.txt
@@ -94,3 +94,36 @@ end
           (command_name))
         (user_command
           (command_name))))))
+
+================================================================================
+If - elseif statement with a:var
+================================================================================
+
+if a:foo == 0
+  Bar
+elseif a:bar == 1
+  Baz
+  Qux
+end
+
+--------------------------------------------------------------------------------
+
+(script_file
+  (if_statement
+    condition: (binary_operation
+      left: (argument
+        (identifier))
+      right: (integer_literal))
+    (body
+      (user_command
+        (command_name)))
+    (elseif_statement
+      condition: (binary_operation
+        left: (argument
+          (identifier))
+        right: (integer_literal))
+      (body
+        (user_command
+          (command_name))
+        (user_command
+          (command_name))))))


### PR DESCRIPTION
Fixed incorrect parsing when `a:var` follows `elseif`.

I also added the following example as test case:

```vim
if a:foo == 0
  Bar
elseif a:bar == 1
  Baz
  Qux
end
```

Before the change, this test case fails, because `:bar == 1` is considered as unknown_builtin_statement:

```diff
 1. If - elseif statement with a:var:

 (script_file
   (if_statement
     condition: (binary_operation
       left: (argument
         (identifier))
       right: (integer_literal))
     (body
       (user_command
         (command_name)))
     (elseif_statement
-        condition: (scope_dict)
+        condition: (binary_operation
+          left: (argument
+            (identifier))
+          right: (integer_literal))
       (body
-          (unknown_builtin_statement
-            (unknown_command_name)
-            (arguments
-              (command_argument)
-              (command_argument)))
         (user_command
           (command_name))
         (user_command
           (command_name))))))
```
